### PR TITLE
Package opam-publish.2.2.0

### DIFF
--- a/packages/opam-publish/opam-publish.2.2.0/opam
+++ b/packages/opam-publish/opam-publish.2.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "1.0"}
+  "lwt_ssl"
+  "ocaml" {>= "4.03.0"}
+  "opam-core" {>= "2.2.0~~"}
+  "opam-format" {>= "2.2.0~~"}
+  "opam-state" {>= "2.2.0~~"}
+  "github" {>= "4.3.2"}
+  "github-unix" {>= "4.3.2"}
+]
+conflicts: [
+  "ssl" {= "0.5.6"}
+]
+flags: plugin
+synopsis: "A tool to ease contributions to opam repositories"
+description: """
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it.
+"""
+url {
+  src:
+    "https://github.com/OCamlPro/opam-publish/archive/refs/tags/2.2.0.tar.gz"
+  checksum: [
+    "md5=932949c1a72112404e2e9b55bf1a2fee"
+    "sha512=9c95d99279d0c8a21c117bd3d4a47f310ec61b404412cea1f5e89ed7171cd37b0aa750f60f03f28cd8028eab03fe7dd08c050ef9a2ffca80cacfa1ae101a40ae"
+  ]
+}


### PR DESCRIPTION
### `opam-publish.2.2.0`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.2.0